### PR TITLE
Fix run_sad

### DIFF
--- a/run_sad
+++ b/run_sad
@@ -2,12 +2,12 @@
 
 cd tripetto-block-text
 npm install
-npm run make
+npm pack
 
 cd ..
 
 cd app
 yarn remove tripetto-block-text
-yarn add file:../tripetto-block-text
+yarn add file:../tripetto-block-text/tripetto-block-text-5.0.0.tgz
 
 yarn start


### PR DESCRIPTION
This problem is related to this issue: https://github.com/yarnpkg/yarn/issues/685

The problem is that yarn copies the entire folder from `./tripetto-block-text/` to `./app/node_modules/tripetto-block-text`. This also includes the `node_modules` folder in `./tripetto-block-text/node_modules` and this folder also contains a version of the `tripetto` package. So now, the text block will use this local instance of Tripetto to register itself to instead of the one used by your app.

The solution here is to run `npm pack` which respects the `.npmignore` file. This will exclude some folders including `node_modules`. After that, the resulting tarball can be used to install the package.